### PR TITLE
Add Dnote under Web Apps (fullstack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This list is for developers who are looking for non-trivial quality applications
 * golang, react, typescript
 * GPLv3 License, AGPLv3 License
 
-> Dnote is a free and open source command line note-taking software that supports a scalable data synchronization among an unliminted number of devices and a mobile-first web interface that can also be installed as a Progressive Web App on mobile devices.
+> Dnote is a free and open source command line note-taking software that supports a scalable data synchronization among an unlimited number of devices and a mobile-first web interface that can also be installed as a Progressive Web App on mobile devices.
 
 
 ## Desktop Apps

--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ This list is for developers who are looking for non-trivial quality applications
 
 > Filestash is a web based file manager that supports a range of protocols and platforms: FTP, SFTP, S3, Minio, Git, WebDAV, Backblaze, Dropbox, Google Drive, LDAP, CalDAV, CardDAV.
 
+### [Dnote](https://github.com/dnote/dnote)
+
+* golang, react, typescript
+* GPLv3 License, AGPLv3 License
+
+> Dnote is a free and open source command line note-taking software that supports a scalable data synchronization among an unliminted number of devices and a mobile-first web interface that can also be installed as a Progressive Web App on mobile devices.
+
+
 ## Desktop Apps
 ----
 


### PR DESCRIPTION
* Add Dnote under the "Web Apps (fullstack)" section.

Thanks for maintaining this useful list.